### PR TITLE
맛집 상세 정보 고도화

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3522,8 +3522,6 @@
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-5.2.4.tgz",
       "integrity": "sha512-gkuCjug16NdGvKm/sydxGVx17uffrSWcEe2xraBtwRCgdYcFxwJAla4OYpASAZT2yhSoxgDiWL9XH6IAChcZJA==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "lodash.clonedeep": "^4.5.0",
         "lru-cache": "^10.0.1"
@@ -3580,8 +3578,6 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
       "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
-      "dev": true,
-      "peer": true,
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -7255,9 +7251,7 @@
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/axios": "^3.0.1",
-        "@nestjs/cache-manager": "^2.1.1",
         "@nestjs/common": "^10.0.0",
         "@nestjs/config": "^3.1.1",
         "@nestjs/core": "^10.0.0",
@@ -22,7 +21,7 @@
         "@nestjs/typeorm": "^10.0.0",
         "axios": "^1.6.0",
         "bcrypt": "^5.1.1",
-        "cache-manager": "^5.2.4",
+        "cache-manager": "^4.1.0",
         "cache-manager-ioredis": "^2.1.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
@@ -3096,6 +3095,11 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3519,12 +3523,13 @@
       }
     },
     "node_modules/cache-manager": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-5.2.4.tgz",
-      "integrity": "sha512-gkuCjug16NdGvKm/sydxGVx17uffrSWcEe2xraBtwRCgdYcFxwJAla4OYpASAZT2yhSoxgDiWL9XH6IAChcZJA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-4.1.0.tgz",
+      "integrity": "sha512-ZGM6dLxrP65bfOZmcviWMadUOCICqpLs92+P/S5tj8onz+k+tB7Gr+SAgOUHCQtfm2gYEQDHiKeul4+tYPOJ8A==",
       "dependencies": {
+        "async": "3.2.3",
         "lodash.clonedeep": "^4.5.0",
-        "lru-cache": "^10.0.1"
+        "lru-cache": "^7.10.1"
       }
     },
     "node_modules/cache-manager-ioredis": {
@@ -3575,11 +3580,11 @@
       }
     },
     "node_modules/cache-manager/node_modules/lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "engines": {
-        "node": "14 || >=16.14"
+        "node": ">=12"
       }
     },
     "node_modules/call-bind": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@nestjs/axios": "^3.0.1",
-    "@nestjs/cache-manager": "^2.1.1",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^10.0.0",
@@ -43,7 +42,7 @@
     "@nestjs/typeorm": "^10.0.0",
     "axios": "^1.6.0",
     "bcrypt": "^5.1.1",
-    "cache-manager": "^5.2.4",
+    "cache-manager": "^4.1.0",
     "cache-manager-ioredis": "^2.1.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,8 +19,6 @@ import { ExternalApiModule } from './feature/externalApi/externalApi.module';
 import { NotificationModule } from './notification/notification.module';
 import { UtilModule } from './util/util.module';
 import { ReviewModule } from './feature/review/review.module';
-import { CacheModule } from '@nestjs/cache-manager';
-import * as redisStore from 'cache-manager-ioredis';
 
 @Module({
   imports: [
@@ -51,12 +49,6 @@ import * as redisStore from 'cache-manager-ioredis';
           namingStrategy: new SnakeNamingStrategy(), // 컬럼명 snake case로 변환
         };
       },
-    }),
-    CacheModule.register({
-      isGlobal: true,
-      store: redisStore,
-      host: 'localhost',
-      port: 6379,
     }),
     AuthModule,
     UserModule,

--- a/src/feature/restaurant/restaurant.service.ts
+++ b/src/feature/restaurant/restaurant.service.ts
@@ -158,7 +158,7 @@ export class RestaurantService {
           data: rest,
           cachedAt: koreaTime.toISOString(),
         }),
-        600,
+        { ttl: 600 },
       );
     }
 
@@ -202,11 +202,11 @@ export class RestaurantService {
       },
     );
 
-    const latestReviews = restaurantWithLatestReviews.reviews;
-
-    if (!latestReviews) {
+    if (!restaurantWithLatestReviews) {
       return;
     }
+
+    const latestReviews = restaurantWithLatestReviews.reviews;
 
     const mergedReviews = [...latestReviews, ...cachedData.reviews];
 
@@ -214,7 +214,7 @@ export class RestaurantService {
     await this.cacheManager.set(
       `restaurant:${id}`,
       JSON.stringify(updatedRestaurant),
-      600,
+      { ttl: 600 },
     );
     return updatedRestaurant;
   }

--- a/src/feature/restaurant/restaurant.service.ts
+++ b/src/feature/restaurant/restaurant.service.ts
@@ -4,7 +4,6 @@ import { Inject, Injectable, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { MoreThan, Repository } from 'typeorm';
 import { Restaurant } from '../../entity/restaurant.entity';
-import { Review } from '../../entity/review.entity';
 import { UtilService } from '../../util/util.service';
 import { FailType } from '../../enum/failType.enum';
 import { GetRestaurantsDto } from './dto/getRestaurant.dto';
@@ -210,7 +209,7 @@ export class RestaurantService {
     }
 
     const mergedReviews = [...latestReviews, ...cachedData.reviews];
-    
+
     const updatedRestaurant = { ...cachedData, reviews: mergedReviews };
     await this.cacheManager.set(
       `restaurant:${id}`,

--- a/src/feature/restaurant/restaurant.service.ts
+++ b/src/feature/restaurant/restaurant.service.ts
@@ -158,7 +158,7 @@ export class RestaurantService {
           data: rest,
           cachedAt: koreaTime.toISOString(),
         }),
-        5,
+        600,
       );
     }
 


### PR DESCRIPTION
## 🚀 이슈 번호
#15 맛집 상세 정보 고도화
<br>

## 💡 변경 이유
1. 레디스에 데이터가 캐싱되어있는 동안 유저가 새로 리뷰를 달 경우 캐시에 저장되도록 수정
2. cache-manager 버전 변경
<br>

## 🔑 주요 변경사항
1. 레디스에 데이터가 캐싱되어있을 때, 캐싱된 시간과 db의 review의 createdAt시간을 비교하여 새로운 리뷰가 있을 경우 캐시의 데이터에 추가하여 다시 캐시에 저장하도록 새로운 함수 추가
- createQueryBuilder로는 시간 비교가 도저히 되지 않아 findOne 메서드를 사용하여 db조회.

2.  ttl 설정을 해도 캐시 만료가 도저히 되지 않는 문제(app.module에 설정할 경우만 만료가 가능한 문제...)로 여러군데 검색을 해봤으나 결국 Nest Js 공식 문서에 근거, cache-manager의 버전 때문이라고 결론을 내리고 버전을 V4로 다운그레이드 하였습니다.
- Nest Js는 기본적으로 cache-manager V4를 타겟팅하여 release되었다고 합니다.
- 참고: 
   -  https://docs.nestjs.com/techniques/caching
   - https://stackoverflow.com/questions/74573177/in-nestjs-i-added-redis-as-cache-manager-when-i-specify-ttl-0-it-throws-a
- ttl 때문이기 때문에 ttl을 사용하지 않는 시군구 목록 고도화는 추가 수정을 하지 않아도 문제가 되지 않을 거라고 생각합니다.

3. 추가로 app.module에 CacheModule.register가 두 번 중복되어 있어서 하나는 제거하였습니다. 

<br>

## 📷 테스트 결과

10분 후 만료되는 것 확인
